### PR TITLE
fix: upgrade android plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,15 @@ plugins {
     alias(libs.plugins.composeMultiplatform) version libs.versions.compose apply false
 }
 
+buildscript {
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin}")
+    }
+}
+
 tasks.register("clean", Delete::class) {
     delete(rootProject.buildDir)
 }
+
+fun getConfigString(name: String): String = extra[name] as String
+fun getConfigInt(name: String): Int = getConfigString(name).toInt()

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,12 @@ org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\=
 
 #Kotlin
 kotlin.code.style=official
+kotlin.native.cacheKind=none
 
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+android.experimental.lint.version=8.1.0
 
 #MPP
 kotlin.mpp.enableCInteropCommonization=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidPlugin = "7.4.2"
+androidPlugin = "8.1.0"
 androidx = "1.7.2"
 androidxCoreKtx = "1.10.1"
 androidxLifecycle = "2.6.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 androidPlugin = "7.4.2"
 androidx = "1.7.2"
-androidxAppCompat = "1.6.1"
 androidxCoreKtx = "1.10.1"
 androidxLifecycle = "2.6.1"
 compose = "1.4.3"
@@ -11,7 +10,6 @@ kotlinxCoroutines = "1.7.3"
 
 [libraries]
 androidxActivityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx" }
-androidxAppCompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppCompat" }
 androidxCoreKtx = { module = "androidx.core:core-ktx", version.ref = "androidxCoreKtx" }
 androidxLifecycleRuntime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
     ).forEach {
         it.binaries.framework {
             baseName = getConfigString("package.name.ios")
+            isStatic = true
         }
     }
 


### PR DESCRIPTION
Jitpack is still failing to build because the current Android gradle plugin can't use gradle 8. This bumps the version of the plugin to be compatible.